### PR TITLE
Guard automation receive endpoints by port

### DIFF
--- a/app/routes/api.ports.$id.receive.clear-last.ts
+++ b/app/routes/api.ports.$id.receive.clear-last.ts
@@ -3,6 +3,16 @@ import { automationManager } from "../server/automation";
 export function action({ params }: { params: { id?: string } }) {
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
+  const state = automationManager.getState();
+  if (!state.enabled) {
+    return new Response("Automation is disabled", { status: 409 });
+  }
+  if (state.portId !== id) {
+    const message = state.portId
+      ? `Automation is active on ${state.portId}, not ${id}`
+      : "Automation is not enabled on this port";
+    return new Response(message, { status: 409 });
+  }
   automationManager.receiveClearLast();
   return Response.json({ ok: true, id });
 }

--- a/app/routes/api.ports.$id.receive.clear.ts
+++ b/app/routes/api.ports.$id.receive.clear.ts
@@ -3,6 +3,16 @@ import { automationManager } from "../server/automation";
 export function action({ params }: { params: { id?: string } }) {
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
+  const state = automationManager.getState();
+  if (!state.enabled) {
+    return new Response("Automation is disabled", { status: 409 });
+  }
+  if (state.portId !== id) {
+    const message = state.portId
+      ? `Automation is active on ${state.portId}, not ${id}`
+      : "Automation is not enabled on this port";
+    return new Response(message, { status: 409 });
+  }
   automationManager.receiveClear();
   return Response.json({ ok: true, id });
 }

--- a/app/routes/api.ports.$id.receive.write-line.ts
+++ b/app/routes/api.ports.$id.receive.write-line.ts
@@ -10,6 +10,17 @@ export async function action({
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
 
+  const state = automationManager.getState();
+  if (!state.enabled) {
+    return new Response("Automation is disabled", { status: 409 });
+  }
+  if (state.portId !== id) {
+    const message = state.portId
+      ? `Automation is active on ${state.portId}, not ${id}`
+      : "Automation is not enabled on this port";
+    return new Response(message, { status: 409 });
+  }
+
   let payload: unknown;
   try {
     payload = await request.json();

--- a/app/routes/api.ports.$id.receive.write.ts
+++ b/app/routes/api.ports.$id.receive.write.ts
@@ -10,6 +10,17 @@ export async function action({
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
 
+  const state = automationManager.getState();
+  if (!state.enabled) {
+    return new Response("Automation is disabled", { status: 409 });
+  }
+  if (state.portId !== id) {
+    const message = state.portId
+      ? `Automation is active on ${state.portId}, not ${id}`
+      : "Automation is not enabled on this port";
+    return new Response(message, { status: 409 });
+  }
+
   let payload: unknown;
   try {
     payload = await request.json();


### PR DESCRIPTION
## Summary
- block manual receive endpoints when automation is disabled or running on a different port
- return informative 409 errors instead of silently logging to the wrong automation session

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68caac16dcd4832ba7b7c90e638ff6aa