### PR TITLE
Unify automation logging with port service

### DIFF
--- a/app/routes/api.ports.$id.receive.clear-last.ts
+++ b/app/routes/api.ports.$id.receive.clear-last.ts
@@ -1,18 +1,13 @@
-import { automationManager } from "../server/automation";
+import { ensureAutomationActiveForPort } from "../server/automation";
+import { portService } from "../server/port-service";
 
 export function action({ params }: { params: { id?: string } }) {
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
-  const state = automationManager.getState();
-  if (!state.enabled) {
-    return new Response("Automation is disabled", { status: 409 });
+  const guard = ensureAutomationActiveForPort(id);
+  if (!guard.ok) {
+    return new Response(guard.reason, { status: 409 });
   }
-  if (state.portId !== id) {
-    const message = state.portId
-      ? `Automation is active on ${state.portId}, not ${id}`
-      : "Automation is not enabled on this port";
-    return new Response(message, { status: 409 });
-  }
-  automationManager.receiveClearLast();
+  portService.receiveClearLast(id);
   return Response.json({ ok: true, id });
 }

--- a/app/routes/api.ports.$id.receive.clear.ts
+++ b/app/routes/api.ports.$id.receive.clear.ts
@@ -1,18 +1,13 @@
-import { automationManager } from "../server/automation";
+import { ensureAutomationActiveForPort } from "../server/automation";
+import { portService } from "../server/port-service";
 
 export function action({ params }: { params: { id?: string } }) {
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
-  const state = automationManager.getState();
-  if (!state.enabled) {
-    return new Response("Automation is disabled", { status: 409 });
+  const guard = ensureAutomationActiveForPort(id);
+  if (!guard.ok) {
+    return new Response(guard.reason, { status: 409 });
   }
-  if (state.portId !== id) {
-    const message = state.portId
-      ? `Automation is active on ${state.portId}, not ${id}`
-      : "Automation is not enabled on this port";
-    return new Response(message, { status: 409 });
-  }
-  automationManager.receiveClear();
+  portService.receiveClear(id);
   return Response.json({ ok: true, id });
 }

--- a/app/routes/api.ports.$id.receive.write.ts
+++ b/app/routes/api.ports.$id.receive.write.ts
@@ -1,4 +1,5 @@
-import { automationManager } from "../server/automation";
+import { ensureAutomationActiveForPort } from "../server/automation";
+import { portService } from "../server/port-service";
 
 export async function action({
   params,
@@ -10,15 +11,9 @@ export async function action({
   const id = params.id;
   if (!id) return new Response("Missing id", { status: 400 });
 
-  const state = automationManager.getState();
-  if (!state.enabled) {
-    return new Response("Automation is disabled", { status: 409 });
-  }
-  if (state.portId !== id) {
-    const message = state.portId
-      ? `Automation is active on ${state.portId}, not ${id}`
-      : "Automation is not enabled on this port";
-    return new Response(message, { status: 409 });
+  const guard = ensureAutomationActiveForPort(id);
+  if (!guard.ok) {
+    return new Response(guard.reason, { status: 409 });
   }
 
   let payload: unknown;
@@ -40,6 +35,6 @@ export async function action({
   }
 
   const colorValue = typeof color === "string" ? color : undefined;
-  automationManager.receiveWrite(message, colorValue);
+  portService.receiveWrite(id, message, colorValue);
   return Response.json({ ok: true, id });
 }

--- a/app/routes/api.ports.$id.write.ts
+++ b/app/routes/api.ports.$id.write.ts
@@ -1,4 +1,4 @@
-import { serialManager } from "../server/serial";
+import { portService } from "../server/port-service";
 
 export async function action({ params, request }: { params: { id?: string }; request: Request }) {
   const id = params.id;
@@ -11,11 +11,9 @@ export async function action({ params, request }: { params: { id?: string }; req
   const hex: string | undefined = body?.hex;
   try {
     if (typeof text === "string") {
-      await serialManager.write(id, text);
+      await portService.sendText(id, text);
     } else if (typeof hex === "string") {
-      const clean = hex.replace(/[^0-9a-fA-F]/g, "");
-      const buf = Buffer.from(clean, "hex");
-      await serialManager.write(id, buf);
+      await portService.sendHex(id, hex);
     } else {
       return new Response("Missing 'text' or 'hex'", { status: 400 });
     }

--- a/app/server/port-console.ts
+++ b/app/server/port-console.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "node:events";
+
+import type { PortId } from "./serial";
+
+export type PortLogType =
+  | "info"
+  | "receive"
+  | "send"
+  | "console"
+  | "error"
+  | "alert";
+
+export interface PortLogEntry {
+  ts: number;
+  type: PortLogType;
+  message: string;
+  color?: string;
+  portId: PortId | null;
+}
+
+const MAX_LOG_ENTRIES = 200;
+
+class PortConsole {
+  private emitter = new EventEmitter();
+  private logs: PortLogEntry[] = [];
+
+  constructor() {
+    this.emitter.setMaxListeners(50);
+  }
+
+  getLogs(filterPort?: PortId | null) {
+    if (!filterPort) {
+      return [...this.logs];
+    }
+    return this.logs.filter((entry) => !entry.portId || entry.portId === filterPort);
+  }
+
+  onLog(cb: (entry: PortLogEntry) => void) {
+    this.emitter.on("log", cb);
+    return () => this.emitter.off("log", cb);
+  }
+
+  log(
+    type: PortLogType,
+    message: string,
+    options?: { portId?: PortId | null; color?: string; timestamp?: number }
+  ) {
+    const normalized: PortLogEntry = {
+      ts: options?.timestamp ?? Date.now(),
+      type,
+      message,
+      color: options?.color,
+      portId: options?.portId ?? null,
+    };
+    this.logs = [
+      ...this.logs.slice(-(MAX_LOG_ENTRIES - 1)),
+      normalized,
+    ];
+    this.emitter.emit("log", normalized);
+    return normalized;
+  }
+
+  receiveWrite(portId: PortId | null, message: string, color?: string) {
+    return this.log("receive", message, { portId, color });
+  }
+
+  receiveWriteLine(portId: PortId | null, message: string, color?: string) {
+    const normalized = message.endsWith("\n") ? message : `${message}\n`;
+    return this.receiveWrite(portId, normalized, color);
+  }
+
+  receiveClear(portId: PortId | null) {
+    return this.log("receive", "[clear]", { portId });
+  }
+
+  receiveClearLast(portId: PortId | null) {
+    return this.log("receive", "[clear-last]", { portId });
+  }
+}
+
+export const portConsole = new PortConsole();

--- a/app/server/port-service.ts
+++ b/app/server/port-service.ts
@@ -1,0 +1,44 @@
+import type { PortId } from "./serial";
+import { serialManager } from "./serial";
+import { portConsole } from "./port-console";
+
+export class PortService {
+  async sendText(id: PortId, text: string) {
+    await serialManager.write(id, text);
+    portConsole.log("send", text, { portId: id });
+  }
+
+  async sendHex(id: PortId, hex: string) {
+    const clean = (hex || "").replace(/[^0-9a-fA-F]/g, "");
+    if (!clean) {
+      throw new Error("Missing hex payload");
+    }
+    const buf = Buffer.from(clean, "hex");
+    await serialManager.write(id, buf);
+    portConsole.log("send", `HEX ${clean.toUpperCase()}`, { portId: id });
+  }
+
+  async sendBytes(id: PortId, data: ArrayLike<number> | Buffer | Uint8Array) {
+    const buf = Buffer.isBuffer(data) ? data : Buffer.from(Array.from(data));
+    await serialManager.write(id, buf);
+    portConsole.log("send", `BYTES ${buf.toString("hex")}`, { portId: id });
+  }
+
+  receiveWrite(id: PortId | null, message: string, color?: string) {
+    portConsole.receiveWrite(id, message, color);
+  }
+
+  receiveWriteLine(id: PortId | null, message: string, color?: string) {
+    portConsole.receiveWriteLine(id, message, color);
+  }
+
+  receiveClear(id: PortId | null) {
+    portConsole.receiveClear(id);
+  }
+
+  receiveClearLast(id: PortId | null) {
+    portConsole.receiveClearLast(id);
+  }
+}
+
+export const portService = new PortService();


### PR DESCRIPTION
## Summary
- introduce a reusable port console that tracks log entries and expose a shared port service for send/receive helpers
- refactor the automation manager and API endpoints to reuse the shared helpers and centralize automation enablement guards
- stream console updates through the standard port SSE endpoint and update the automation UI to consume the shared stream

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cc0214b044832bb2e905ee8bd74dc5